### PR TITLE
Add asdf to .gitignore to ensure local java version properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 !**/src/main/**
 !**/src/test/**
 .sdkmanrc
+.tool-versions
 
 ### STS ###
 .apt_generated


### PR DESCRIPTION
Just a helper for the asdf tool to ensure I use the proper Java version when in this directory.