### PR TITLE
Add support for HTMX partials.

### DIFF
--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxMvcConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxMvcConfiguration.java
@@ -1,18 +1,36 @@
 package io.github.wimdeblauwe.hsbt.mvc;
 
+import java.util.List;
+
+import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.ViewResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import org.thymeleaf.spring5.view.ThymeleafViewResolver;
 
-import java.util.List;
-
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnWebApplication
 public class HtmxMvcConfiguration implements WebMvcRegistrations, WebMvcConfigurer {
+
+    private final ViewResolver resolver;
+    private final ObjectFactory<LocaleResolver> locales;
+
+    HtmxMvcConfiguration(ThymeleafViewResolver resolver, ObjectFactory<LocaleResolver> locales) {
+
+      Assert.notNull(resolver, "ViewResovler must not be null!");
+      Assert.notNull(locales, "LocaleResolver must not be null!");
+
+      this.resolver = resolver;
+      this.locales = locales;
+    }
+
     @Override
     public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
         return new HtmxRequestMappingHandlerMapping();
@@ -21,6 +39,7 @@ public class HtmxMvcConfiguration implements WebMvcRegistrations, WebMvcConfigur
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new HtmxHandlerInterceptor());
+        registry.addInterceptor(new HtmxViewHandlerInterceptor(resolver, locales));
     }
 
     @Override

--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxPartials.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxPartials.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.wimdeblauwe.hsbt.mvc;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.util.Assert;
+
+/**
+ * Representation of HTMX partials.
+ *
+ * @author Oliver Drotbohm
+ */
+public class HtmxPartials {
+
+	private final Collection<Partial> partials;
+
+	public HtmxPartials() {
+		this.partials = new ArrayList<>();
+	}
+	
+	HtmxPartials(Collection<Partial> partials) {
+		this.partials = partials;
+	}
+
+	/**
+	 * Append the rendered fragment.
+	 *
+	 * @param target must not be {@literal null} or empty.
+	 * @return
+	 */
+	public HtmxPartialsBuilder append(String target) {
+		return new HtmxPartialsBuilder(partials, target, Action.APPEND);
+	}
+
+	/**
+	 * Prepend the rendered fragment.
+	 *
+	 * @param target must not be {@literal null} or empty.
+	 * @return
+	 */
+	public HtmxPartialsBuilder prepend(String target) {
+		return new HtmxPartialsBuilder(partials, target, Action.PREPEND);
+	}
+
+	/**
+	 * Remove the rendered fragment.
+	 *
+	 * @param template must not be {@literal null} or empty.
+	 * @return
+	 */
+	public HtmxPartials remove(String target) {
+		return new HtmxPartialsBuilder(partials, target, Action.REMOVE)
+				.with("¯\\_(ツ)_/¯");
+	}
+
+	/**
+	 * Replace the rendered fragment.
+	 *
+	 * @param target must not be {@literal null} or empty.
+	 * @return
+	 */
+	public HtmxPartialsBuilder replace(String target) {
+		return new HtmxPartialsBuilder(partials, target, Action.REPLACE);
+	}
+
+	/**
+	 * Update the rendered fragment.
+	 *
+	 * @param target must not be {@literal null} or empty.
+	 * @return
+	 */
+	public HtmxPartialsBuilder update(String target) {
+		return new HtmxPartialsBuilder(partials, target, Action.UPDATE);
+	}
+	
+	Iterable<Partial> toIterable() {
+		return () -> partials.iterator();
+	}
+
+	public static class HtmxPartialsBuilder {
+
+		private Collection<Partial> streams;
+		private String target;
+		private Action action;
+
+		HtmxPartialsBuilder(Collection<Partial> streams, String target, Action action) {
+			this.streams = streams;
+			this.target = target;
+			this.action = action;
+		}
+
+		/**
+		 * @param templateOrFragment the identifier of a template or fragment.
+		 * @return will never be {@literal null}.
+		 */
+		public HtmxPartials with(String templateOrFragment) {
+			return and(new Partial(action, target, templateOrFragment));
+		}
+
+		/**
+		 * Renders the fragment with the current target name within the given template.
+		 *
+		 * @param template must not be {@literal null} or empty.
+		 * @return will never be {@literal null}.
+		 */
+		public HtmxPartials withinTemplate(String template) {
+
+			Assert.hasText(template, "Template name must not be null or empty!");
+
+			return and(new Partial(action, target, template.concat(" :: ".concat(target))));
+		}
+
+		/**
+		 * Renders the given fragment as Turbo Stream.
+		 *
+		 * @param fragment must not be {@literal null} or empty and a valid fragment identifier.
+		 * @return will never be {@literal null}.
+		 */
+		public HtmxPartials withFragment(String fragment) {
+
+			Assert.hasText(fragment, "Fragment must not be null or empty!");
+			Assert.isTrue(fragment.contains("::"), () -> "Invalid fragment identifier " + fragment + "!");
+
+			return and(new Partial(action, target, fragment));
+		}
+
+		private HtmxPartials and(Partial stream) {
+
+			List<Partial> list = new ArrayList<>(streams);
+			list.add(stream);
+
+			return new HtmxPartials(list);
+		}
+	}
+
+
+	enum Action {
+
+		APPEND,
+
+		PREPEND,
+
+		REPLACE,
+
+		UPDATE,
+
+		REMOVE;
+
+		String toAttribute() {
+
+			switch (this) {
+				case APPEND:
+					return "beforeend";
+				default:
+					return "true";
+			}
+		}
+	}
+	
+	static class Partial {
+
+		private final Action action;
+		private final String target, template;
+		
+		Partial(Action action, String target, String template) {
+			this.action = action;
+			this.target = target;
+			this.template = template;
+		}
+		
+		/**
+		 * @return the action
+		 */
+		public Action getAction() {
+			return action;
+		}
+		
+		/**
+		 * @return the template
+		 */
+		String getTemplate() {
+			return template;
+		}
+		
+
+		String openWrapper() {
+			return String.format("<div id=\"%s\" hx-swap-oob=\"%s\">\n", target,
+					action.toAttribute());
+		}
+
+		String closeWrapper() {
+			return "\n</div>\n";
+		}
+
+		boolean isRemove() {
+			return Action.REMOVE.equals(action);
+		}
+
+		boolean isReplace() {
+			return Action.REPLACE.equals(action);
+		}
+	}
+}

--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxViewHandlerInterceptor.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxViewHandlerInterceptor.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.wimdeblauwe.hsbt.mvc;
+
+import io.github.wimdeblauwe.hsbt.mvc.HtmxPartials.Partial;
+
+import java.io.PrintWriter;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.util.Assert;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.LocaleResolver;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.View;
+import org.springframework.web.servlet.ViewResolver;
+
+/**
+ * A {@link HandlerInterceptor} that turns {@link HtmxPartials} instances returned from controller methods into a
+ *
+ * @author Oliver Drotbohm
+ */
+class HtmxViewHandlerInterceptor implements HandlerInterceptor {
+
+  private final ViewResolver views;
+  private final ObjectFactory<LocaleResolver> locales;
+
+	public HtmxViewHandlerInterceptor(ViewResolver views, ObjectFactory<LocaleResolver> locales) {
+		this.views = views;
+		this.locales = locales;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.web.servlet.HandlerInterceptor#postHandle(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse, java.lang.Object, org.springframework.web.servlet.ModelAndView)
+	 */
+	@Override
+	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
+			ModelAndView modelAndView) throws Exception {
+
+		if (modelAndView == null || !HandlerMethod.class.isInstance(handler)) {
+			return;
+		}
+
+		HandlerMethod method = (HandlerMethod) handler;
+
+		if (!method.getReturnType().getParameterType().equals(HtmxPartials.class)) {
+			return;
+		}
+
+		Object attribute = modelAndView.getModel().get("htmxPartials");
+
+		if (!HtmxPartials.class.isInstance(attribute)) {
+			return;
+		}
+
+		HtmxPartials streams = (HtmxPartials) attribute;
+
+		modelAndView.setView(toView(streams));
+	}
+	
+	private View toView(HtmxPartials partials) {
+
+		Assert.notNull(partials, "HtmxPartials must not be null!");
+
+		return (model, request, response) -> {
+
+			Locale locale = locales.getObject().resolveLocale(request);
+			PrintWriter writer = response.getWriter();
+
+			for (Partial partial : partials.toIterable()) {
+
+				writer.write(partial.openWrapper());
+
+				if (!partial.isRemove()) {
+					views.resolveViewName(partial.getTemplate(), locale)
+							.render(model, request, response);
+				}
+
+				writer.write(partial.closeWrapper());
+			}
+		};
+	}
+}


### PR DESCRIPTION
Introduce HtmxPartials to provide a convenient API for controller methods to specify Thymeleaf fragments to be rendered to ultimately trigger different parts of the page updated. The abstraction is handled in a custom HandlerInterceptor that renders a view that triggers the rendering of the registered fragments individually.

I've stripped down a lot of stuff from what I previously had in [Spring Playground](https://github.com/odrotbohm/spring-playground/tree/main/htmx-spring-boot). The server sent events support is completely gone for now as that allows a significantly simplified arrangement and less abstractions to introduce. Feel free to massage as you see fit.