### PR TITLE
Fix link to https://htmx.org/ in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 # Spring Boot and Thymeleaf library for htmx
 
 This library provides helper classes and a [Thymeleaf](https://www.thymeleaf.org/) dialect
-to make it easy to work with [htmx](www.htmx.org)
+to make it easy to work with [htmx](https://htmx.org/)
 in a [Spring Boot](https://spring.io/projects/spring-boot) application.
 
 More information about htmx can be viewed on [their website](https://htmx.org/).

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ This library provides helper classes and a [Thymeleaf](https://www.thymeleaf.org
 to make it easy to work with [htmx](www.htmx.org)
 in a [Spring Boot](https://spring.io/projects/spring-boot) application.
 
-More information about htmx can be viewed on [their website](www.htmx.org).
+More information about htmx can be viewed on [their website](https://htmx.org/).
 
 ## Installation
 


### PR DESCRIPTION
A the moment it will link to https://github.com/wimdeblauwe/htmx-spring-boot-thymeleaf/blob/main/www.htmx.org