### PR TITLE
Issue #42: Moving HxTrigger and HxRefresh handling to preHandle to be…

### DIFF
--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxHandlerInterceptor.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxHandlerInterceptor.java
@@ -13,15 +13,16 @@ import static io.github.wimdeblauwe.hsbt.mvc.HtmxResponseHeader.*;
 
 public class HtmxHandlerInterceptor implements HandlerInterceptor {
     @Override
-    public void postHandle(HttpServletRequest request,
+    public boolean preHandle(HttpServletRequest request,
                            HttpServletResponse response,
-                           Object handler,
-                           ModelAndView modelAndView) throws Exception {
+                           Object handler) {
         if (handler instanceof HandlerMethod) {
             Method method = ((HandlerMethod) handler).getMethod();
             setHxTrigger(response, method);
             setHxRefresh(response, method);
         }
+
+        return true;
     }
 
     private void setHxTrigger(HttpServletResponse response, Method method) {


### PR DESCRIPTION
… compatible with @ResponseBody

Due to the nature of how ResponseBody is processed, a request is committed (therefore silently immutable) *before* an interceptor's postHandle is ever called. Therefore, these headers were being lost in this ResponseBody situation (and maybe in other unknown situations). The fix is to set the headers instead in preHandle(), as it makes no difference to existing functionality but fixes this issue.