### PR TITLE
println() method removed from HtmxHandlerMethodArgumentResolver

### DIFF
--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxHandlerMethodArgumentResolver.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxHandlerMethodArgumentResolver.java
@@ -22,8 +22,6 @@ public class HtmxHandlerMethodArgumentResolver implements HandlerMethodArgumentR
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
-        Object nativeRequest = webRequest.getNativeRequest();
-        System.out.println("nativeRequest = " + nativeRequest);
         return createHtmxRequest(Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)));
     }
 


### PR DESCRIPTION
- Removed System.out.println() from HtmxHandlerMethodArgumentResolver
- Removed unwanted object of native request

fixes: #47