### PR TITLE
Allow templates to be added as resolved Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,20 @@ public HtmxResponse getMainAndPartial(Model model){
         }
 ```
 
+An `HtmxResponse` can be formed from view names, as above, or fully resolved `View` instances, if the controller knows how
+to do that, or from `ModelAndView` instances (resolved or unresolved). For example:
+
+```java
+@GetMapping("/partials/main-and-partial")
+public HtmxResponse getMainAndPartial(Model model){
+        return new HtmxResponse()
+        .addTemplate(new ModelAndView("users :: list")
+        .addTemplate(new ModelAndView("users :: count", Map.of("userCount",5));
+        }
+```
+
+Using `ModelAndView` means that each fragment can have its own model (which is merged with the controller model before rendering).
+
 ### Spring Security
 
 The library has an `HxRefreshHeaderAuthenticationEntryPoint` that you can use to have htmx force a full page browser

--- a/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxMvcConfiguration.java
+++ b/src/main/java/io/github/wimdeblauwe/hsbt/mvc/HtmxMvcConfiguration.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
-import org.springframework.context.ApplicationContext;
 import org.springframework.util.Assert;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.LocaleResolver;

--- a/src/test/java/io/github/wimdeblauwe/hsbt/mvc/HtmxPartialHandlerInterceptorTest.java
+++ b/src/test/java/io/github/wimdeblauwe/hsbt/mvc/HtmxPartialHandlerInterceptorTest.java
@@ -1,5 +1,16 @@
 package io.github.wimdeblauwe.hsbt.mvc;
 
+import static io.github.wimdeblauwe.hsbt.mvc.support.PartialXpathResultMatchers.partialXpath;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.xpath;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -7,13 +18,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-
-import static io.github.wimdeblauwe.hsbt.mvc.support.PartialXpathResultMatchers.partialXpath;
-import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PartialsController.class)
 @WithMockUser
@@ -32,6 +36,23 @@ class HtmxPartialHandlerInterceptorTest {
                .andExpect(status().isOk())
                .andExpect(xpath("/ul").exists())
                .andExpect(xpath("/ul[@hx-swap-oob='true']").doesNotExist());
+    }
+
+    @Test
+    public void testASingleViewCanBeReturned() throws Exception {
+        mockMvc.perform(get("/partials/view"))
+                .andDo(MockMvcResultHandlers.print())
+               .andExpect(status().isOk())
+               .andExpect(xpath("/ul").exists());
+    }
+
+    @Test
+    public void testASingleModelAndViewCanBeReturned() throws Exception {
+        mockMvc.perform(get("/partials/mav"))
+                .andDo(MockMvcResultHandlers.print())
+               .andExpect(status().isOk())
+               .andExpect(partialXpath("/span[@id='item']").exists())
+               .andExpect(content().string(containsString("Foo")));
     }
 
     @Test

--- a/src/test/java/io/github/wimdeblauwe/hsbt/mvc/HtmxResponseTest.java
+++ b/src/test/java/io/github/wimdeblauwe/hsbt/mvc/HtmxResponseTest.java
@@ -27,7 +27,7 @@ public class HtmxResponseTest {
         String myTemplate = "myTemplate";
         sut.addTemplate(myTemplate);
 
-        assertThat(sut.getTemplates()).containsExactly(myTemplate);
+        assertThat(sut.getTemplates()).extracting(mav -> mav.getViewName()).containsExactly(myTemplate);
     }
 
     @Test
@@ -38,7 +38,7 @@ public class HtmxResponseTest {
         sut.addTemplate(myTemplateAndFragment);
         sut.addTemplate(myTemplate);
 
-        assertThat(sut.getTemplates()).containsExactly(myTemplate, myTemplateAndFragment);
+        assertThat(sut.getTemplates()).extracting(mav -> mav.getViewName()).containsExactly(myTemplate, myTemplateAndFragment);
     }
 
     @Test
@@ -91,7 +91,7 @@ public class HtmxResponseTest {
         sut.addTemplate(template1);
         sut.addTemplate(template2);
 
-        assertThat(sut.getTemplates()).containsExactly(template1, template2);
+        assertThat(sut.getTemplates()).extracting(mav -> mav.getViewName()).containsExactly(template1, template2);
     }
 
     @Test
@@ -103,7 +103,7 @@ public class HtmxResponseTest {
 
         response1.and(response2);
 
-        assertThat(response1.getTemplates())
+        assertThat(response1.getTemplates()).extracting(mav -> mav.getViewName())
                 .hasSize(4)
                 .containsExactly("response1 :: template 11",
                                  "response1 :: template 12",

--- a/src/test/java/io/github/wimdeblauwe/hsbt/mvc/PartialsController.java
+++ b/src/test/java/io/github/wimdeblauwe/hsbt/mvc/PartialsController.java
@@ -1,11 +1,18 @@
 package io.github.wimdeblauwe.hsbt.mvc;
 
+import static io.github.wimdeblauwe.hsbt.mvc.CommonHtmxResponses.sendAlertPartial;
+
+import java.util.Map;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.ModelAndView;
+import org.springframework.web.servlet.view.AbstractView;
 
-import static io.github.wimdeblauwe.hsbt.mvc.CommonHtmxResponses.sendAlertPartial;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 public class PartialsController {
@@ -39,6 +46,23 @@ public class PartialsController {
     @GetMapping("/partials/first")
     public HtmxResponse getFirstPartials() {
         return new HtmxResponse().addTemplate("users :: list");
+    }
+
+    @GetMapping("/partials/view")
+    public HtmxResponse getFirstView() {
+        return new HtmxResponse().addTemplate(new AbstractView() {
+            @Override
+            protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request,
+                    HttpServletResponse response) throws Exception {
+                        response.getWriter().write("<ul><li>A list</li></ul>");
+            }
+            
+        });
+    }
+
+    @GetMapping("/partials/mav")
+    public HtmxResponse getFirstModelAndView() {
+        return new HtmxResponse().addTemplate(new ModelAndView("fragments :: todoItem", Map.of("item", new TodoItem("Foo"))));
     }
 
     @GetMapping("/partials/main-and-partial")


### PR DESCRIPTION
Also as fully-formed `ModelAndView`, or (as before) as view name `String` to be resolved later.

See https://github.com/wimdeblauwe/htmx-spring-boot-thymeleaf/discussions/53